### PR TITLE
Refatoração para pipeline de podcast

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copie este arquivo para .env e ajuste as variáveis de ambiente
+GEMINI_API_KEY=
+# Caminho para o checkpoint do modelo F5-TTS
+F5_MODEL_PATH=F5-TTS-pt-br
+# Áudio de referência para síntese (opcional)
+REF_AUDIO=ref_audios/ref.wav

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# My_Projeto
+# Podcast IA em Português
+
+Este projeto gera um podcast em áudio utilizando um modelo de linguagem e o F5‑TTS para síntese de voz em português do Brasil.
+
+## Requisitos
+- Python 3.12
+- Dependências do `requirements.txt`
+- Modelo F5‑TTS (configure `F5_MODEL_PATH` no arquivo `.env`)
+
+## Uso rápido
+1. Copie `.env.example` para `.env` e ajuste as variáveis.
+2. Instale as dependências:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Execute o script principal passando um prompt:
+   ```bash
+   python main.py "tema do podcast" --output output/podcast.mp3
+   ```
+
+O áudio final será salvo no caminho indicado.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,0 @@
-# Copie este arquivo para .env e defina sua chave da API Gemini
-GEMINI_API_KEY=
-# Caminho para o modelo F5-TTS (opcional)
-F5_MODEL_PATH=

--- a/main.py
+++ b/main.py
@@ -1,4 +1,21 @@
-# Copie este arquivo para .env e defina sua chave da API Gemini
-GEMINI_API_KEY=
-# Caminho para o modelo F5-TTS (opcional)
-F5_MODEL_PATH=
+import argparse
+import os
+from pipeline.workflow import create_podcast
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Gera um podcast em áudio a partir de um prompt")
+    parser.add_argument("prompt", help="Texto ou tema para gerar o roteiro")
+    parser.add_argument("--output", default="output/podcast.mp3", help="Arquivo de saída do áudio")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    audio = create_podcast(args.prompt, args.output)
+    print(f"Áudio gerado em: {audio}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,4 +1,14 @@
-# Copie este arquivo para .env e defina sua chave da API Gemini
-GEMINI_API_KEY=
-# Caminho para o modelo F5-TTS (opcional)
-F5_MODEL_PATH=
+"""Módulos para geração de podcast em português."""
+from .config import GEMINI_API_KEY, F5_MODEL_PATH, REF_AUDIO
+from .llm import LLM
+from .tts import TTS
+from .workflow import create_podcast
+
+__all__ = [
+    "LLM",
+    "TTS",
+    "create_podcast",
+    "GEMINI_API_KEY",
+    "F5_MODEL_PATH",
+    "REF_AUDIO",
+]

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -1,4 +1,5 @@
-# Copie este arquivo para .env e defina sua chave da API Gemini
-GEMINI_API_KEY=
-# Caminho para o modelo F5-TTS (opcional)
-F5_MODEL_PATH=
+import os
+
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+F5_MODEL_PATH = os.getenv("F5_MODEL_PATH", "F5-TTS-pt-br")
+REF_AUDIO = os.getenv("REF_AUDIO")

--- a/pipeline/extract.py
+++ b/pipeline/extract.py
@@ -1,4 +1,6 @@
-# Copie este arquivo para .env e defina sua chave da API Gemini
-GEMINI_API_KEY=
-# Caminho para o modelo F5-TTS (opcional)
-F5_MODEL_PATH=
+from pathlib import Path
+
+
+def extract_text(path: str) -> str:
+    """Lê o conteúdo de um arquivo de texto."""
+    return Path(path).read_text(encoding="utf-8")

--- a/pipeline/llm.py
+++ b/pipeline/llm.py
@@ -1,4 +1,10 @@
-# Copie este arquivo para .env e defina sua chave da API Gemini
-GEMINI_API_KEY=
-# Caminho para o modelo F5-TTS (opcional)
-F5_MODEL_PATH=
+from transformers import pipeline
+
+
+class LLM:
+    def __init__(self, model_name: str = "pierreguillou/gpt2-small-portuguese", device: str = "cpu"):
+        self.generator = pipeline("text-generation", model=model_name, device=0 if device == "cuda" else -1)
+
+    def generate(self, prompt: str, max_new_tokens: int = 200) -> str:
+        outputs = self.generator(prompt, max_new_tokens=max_new_tokens)
+        return outputs[0]["generated_text"]

--- a/pipeline/tts.py
+++ b/pipeline/tts.py
@@ -1,4 +1,24 @@
-# Copie este arquivo para .env e defina sua chave da API Gemini
-GEMINI_API_KEY=
-# Caminho para o modelo F5-TTS (opcional)
-F5_MODEL_PATH=
+import sys
+from pathlib import Path
+from .config import F5_MODEL_PATH, REF_AUDIO
+
+# Adiciona o caminho do módulo local F5-TTS-pt-br
+sys.path.append(str(Path(__file__).resolve().parents[1] / "F5-TTS-pt-br"))
+from AgentF5TTSChunk import AgentF5TTS
+
+
+class TTS:
+    def __init__(self, model_path: str | None = None, ref_audio: str | None = None):
+        self.model_path = model_path or F5_MODEL_PATH
+        self.ref_audio = ref_audio or REF_AUDIO
+        self.agent = AgentF5TTS(ckpt_file=self.model_path, vocoder_name="vocos")
+
+    def synthesize(self, text_file: str, output_audio: str, convert_to_mp3: bool = True) -> str:
+        Path(output_audio).parent.mkdir(parents=True, exist_ok=True)
+        self.agent.generate_speech(
+            text_file=text_file,
+            output_audio_file=output_audio,
+            ref_audio=self.ref_audio,
+            convert_to_mp3=convert_to_mp3,
+        )
+        return output_audio

--- a/pipeline/workflow.py
+++ b/pipeline/workflow.py
@@ -1,4 +1,13 @@
-# Copie este arquivo para .env e defina sua chave da API Gemini
-GEMINI_API_KEY=
-# Caminho para o modelo F5-TTS (opcional)
-F5_MODEL_PATH=
+from pathlib import Path
+from .llm import LLM
+from .tts import TTS
+
+
+def create_podcast(prompt: str, output_audio: str) -> str:
+    llm = LLM()
+    script = llm.generate(prompt)
+    text_path = Path("script.txt")
+    text_path.write_text(script, encoding="utf-8")
+
+    tts = TTS()
+    return tts.synthesize(str(text_path), output_audio)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ safetensors
 f5-tts
 streamlit
 PySimpleGUI
+transformers


### PR DESCRIPTION
## Summary
- rename env sample
- add simple CLI to generate podcast audio
- implement basic pipeline with LLM and TTS wrappers
- document usage in README
- fix requirements list

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `import pipeline` *(failed: heavy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684793aea1d4832facbe73eccd410878